### PR TITLE
Add more Python package version requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ The code was used with the following settings:
 - python3
 - tensorflow-gpu==1.7.0
 - scikit-image==0.13.1
-- numpy==1.15.4
-- scipy==1.1.0
+- numpy==1.14.2
+- scipy==1.0.0
 
 ### Datasets
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ The code was used with the following settings:
 - python3
 - tensorflow-gpu==1.7.0
 - scikit-image==0.13.1
+- numpy==1.15.4
+- scipy==1.1.0
 
 ### Datasets
 


### PR DESCRIPTION
Got some errors when doing a fresh `conda` install with just the given requirements; had to downgrade both `numpy` and `scipy` versions to get the Omniglot image preprocessing (`python utils.py`) running.

Figured a good numpy version from a [scikit-image comment](https://github.com/scikit-image/scikit-image/issues/3586#issuecomment-455190679).
Guessed the scipy version by looking at the [releases](https://github.com/scipy/scipy/releases) and from https://stackoverflow.com/questions/56204985/how-to-fix-scipy-misc-has-no-attribute-imresize.

These versions might not be the same as those used in the original environment; so it might be an even better idea to drop in the output from either `conda list` or `pip list` in a `requirements.txt`:
```
conda list --export > requirements.txt
```
or
```
pip freeze > requirements.txt
```
And include some instructions in the README like:
```
conda create --name <envname> --file requirements.txt
```
or
```
pip install -r requirements.txt
```