### PR TITLE
Missing test data iterator in finetuned config for omniglot

### DIFF
--- a/config_rnn/bn2_omniglot_tp_ft_1s_20w.py
+++ b/config_rnn/bn2_omniglot_tp_ft_1s_20w.py
@@ -29,6 +29,12 @@ train_data_iter = data_iter.OmniglotEpisodesDataIterator(seq_len=seq_len,
                                                          rng=rng,
                                                          augment=True)
 
+test_data_iter = data_iter.OmniglotTestBatchSeqDataIterator(seq_len=seq_len,
+                                                            batch_size=batch_size,
+                                                            set='test',
+                                                            rng=rng_test,
+                                                            augment=False)
+
 test_data_iter2 = data_iter.OmniglotTestBatchSeqDataIterator(seq_len=seq_len,
                                                              batch_size=batch_size,
                                                              set='test',

--- a/config_rnn/bn2_omniglot_tp_ft_1s_20w.py
+++ b/config_rnn/bn2_omniglot_tp_ft_1s_20w.py
@@ -29,11 +29,11 @@ train_data_iter = data_iter.OmniglotEpisodesDataIterator(seq_len=seq_len,
                                                          rng=rng,
                                                          augment=True)
 
-test_data_iter = data_iter.OmniglotTestBatchSeqDataIterator(seq_len=seq_len,
-                                                            batch_size=batch_size,
-                                                            set='test',
-                                                            rng=rng_test,
-                                                            augment=False)
+test_data_iter = data_iter.OmniglotExchSeqDataIterator(seq_len=seq_len,
+                                                       batch_size=batch_size,
+                                                       set='test',
+                                                       augment=False,
+                                                       rng=rng_test)
 
 test_data_iter2 = data_iter.OmniglotTestBatchSeqDataIterator(seq_len=seq_len,
                                                              batch_size=batch_size,


### PR DESCRIPTION
Running the sample generation command in the README 
```
CUDA_VISIBLE_DEVICES=0 python3 -m config_rnn.test_samples  --config_name bn2_omniglot_tp_ft_1s_20w
```
results in the error
```
AttributeError: module 'config_rnn.bn2_omniglot_tp_ft_1s_20w' has no attribute 'test_data_iter'
```
Is this the correct test data iterator that should be in there?